### PR TITLE
Branding: use nyu colors

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -6,25 +6,25 @@
 
 /* You can override the default Infima variables here. */
 :root {
-  --ifm-color-primary: #2e8555;
-  --ifm-color-primary-dark: #29784c;
-  --ifm-color-primary-darker: #277148;
-  --ifm-color-primary-darkest: #205d3b;
-  --ifm-color-primary-light: #33925d;
-  --ifm-color-primary-lighter: #359962;
-  --ifm-color-primary-lightest: #3cad6e;
+  --ifm-color-primary: #57068c;
+  --ifm-color-primary-dark: #4e057e;
+  --ifm-color-primary-darker: #4a0577;
+  --ifm-color-primary-darkest: #3d0462;
+  --ifm-color-primary-light: #60079a;
+  --ifm-color-primary-lighter: #6407a1;
+  --ifm-color-primary-lightest: #7108b6;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
 [data-theme='dark'] {
-  --ifm-color-primary: #25c2a0;
-  --ifm-color-primary-dark: #21af90;
-  --ifm-color-primary-darker: #1fa588;
-  --ifm-color-primary-darkest: #1a8870;
-  --ifm-color-primary-light: #29d5b0;
-  --ifm-color-primary-lighter: #32d8b4;
-  --ifm-color-primary-lightest: #4fddbf;
+  --ifm-color-primary: #eee6f3;
+  --ifm-color-primary-dark: #d8c6e4;
+  --ifm-color-primary-darker: #cdb6dc;
+  --ifm-color-primary-darkest: #ad86c5;
+  --ifm-color-primary-light: #ffffff;
+  --ifm-color-primary-lighter: #ffffff;
+  --ifm-color-primary-lightest: #ffffff;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 }


### PR DESCRIPTION
Use primary colors from https://www.nyu.edu/employees/resources-and-services/media-and-communications/nyu-brand-guidelines/designing-in-our-style/nyu-colors.html

Generate colorscheme palettes with [WCAG-AA contrast ratio](https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast) using https://docusaurus.io/docs/styling-layout#styling-your-site-with-infima